### PR TITLE
Fix rtn_table circular reference

### DIFF
--- a/tritondse/symbolic_explorator.py
+++ b/tritondse/symbolic_explorator.py
@@ -138,7 +138,7 @@ class SymbolicExplorator(object):
             execution.load(self.loader)
         else:
             execution.load_process(ProcessState())
-        self.current_executor = execution
+        # self.current_executor = execution
 
         # increment exec_count
         self._exec_count += 1
@@ -161,6 +161,11 @@ class SymbolicExplorator(object):
         self._total_emulation_time += expl_ts
 
         logger.info(f"Emulation: {self._fmt_secs(expl_ts)} | Solving: {self._fmt_secs(solve_time)} | Elapsed: {self._fmt_secs(self.__time_delta())}\n")
+
+        self.current_executor = None
+        del execution.rtn_table
+        del cbs
+        # del execution
 
     def step(self) -> None:
         """
@@ -208,7 +213,7 @@ class SymbolicExplorator(object):
 
         try:
             while self.seeds_manager.seeds_available() and not self._stop:
-                gc.collect()
+                # gc.collect()
                 self.step()
 
             if self.status == ExplorationStatus.RUNNING:


### PR DESCRIPTION
This PR fixes a circular reference issue in `SymbolicExecutor`. The `rtn_table` were holding references to the `SymbolicExecutor` instance it belonged to through the `___default_stub` method.