### PR TITLE
fix symbolic register injection

### DIFF
--- a/tritondse/symbolic_executor.py
+++ b/tritondse/symbolic_executor.py
@@ -839,7 +839,7 @@ class SymbolicExecutor(object):
         if isinstance(value, int):
             self.pstate.write_register(reg, value)                         # write concrete value in register
             sym_var = self.pstate.symbolize_register(reg, f"{name}[{0}]")  # symbolize value
-            self.symbolic_seed.variables[name] = sym_var               # add the symbolic variables to symbolic seed
+            self.symbolic_seed.variables[name] = [sym_var]                 # add the symbolic variables to symbolic seed
         else:  # meant to be bytes
             logger.warning("variable injected in registers have to be integer values")
 


### PR DESCRIPTION
This MR, fix an issue when using ``inject_symbolic_variable_register``.
We were overriding the ``symbolic_seed.variables[name]`` originally a list into an object.

The consequence is that we were trying to interate the object as a list: https://github.com/quarkslab/tritondse/blob/main/tritondse/symbolic_executor.py#L713 which failed..

I can't figure out how we could still have this issue. 