### PR TITLE
Fix breaking changes induced by lief

### DIFF
--- a/tritondse/loaders/program.py
+++ b/tritondse/loaders/program.py
@@ -38,9 +38,10 @@ class Program(Loader):
         super(Program, self).__init__(path)
 
         self._arch_mapper = {
-            lief.ARCHITECTURES.ARM:   Architecture.ARM32,
-            lief.ARCHITECTURES.ARM64: Architecture.AARCH64,
-            lief.ARCHITECTURES.X86:   Architecture.X86
+            lief.Header.ARCHITECTURES.ARM:   Architecture.ARM32,
+            lief.Header.ARCHITECTURES.ARM64: Architecture.AARCH64,
+            lief.Header.ARCHITECTURES.X86:   Architecture.X86,
+            lief.Header.ARCHITECTURES.X86_64:   Architecture.X86_64
         }
 
         self._plfm_mapper = {
@@ -82,8 +83,8 @@ class Program(Loader):
 
     @property
     def endianness(self) -> Endian:
-        return {lief.ENDIANNESS.LITTLE: Endian.LITTLE,
-                lief.ENDIANNESS.BIG: Endian.BIG}[self._binary.abstract.header.endianness]
+        return {lief.Header.ENDIANNESS.LITTLE: Endian.LITTLE,
+                lief.Header.ENDIANNESS.BIG: Endian.BIG}[self._binary.abstract.header.endianness]
 
     @property
     def entry_point(self) -> Addr:


### PR DESCRIPTION
Hi,

I recently tried to load an X86_64 ELF but came accross the following error:
```shell
/curr ❯ python solve.py
Traceback (most recent call last):
  File "solve.py", line 11, in <module>
    main()
    ~~~~^^
  File "solve.py", line 5, in main
    p = Program("./test.elf")
  File "/home/alexandre/tools/venv/lib/python3.13/site-packages/tritondse/loaders/program.py", line 41, in __init__
    lief.ARCHITECTURES.ARM:   Architecture.ARM32,
    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'lief' has no attribute 'ARCHITECTURES'
```
I have moved both `ARCHITECTURES` and `ENDIANNESS` to the correct location.