### PR TITLE
Add an ELF x86_64 coredump loader

### DIFF
--- a/tritondse/__init__.py
+++ b/tritondse/__init__.py
@@ -1,5 +1,6 @@
 from .config                import Config
 from .loaders.program       import Program
+from .loaders.coredump      import CoredumpLoader
 from .loaders.quokkaprogram import QuokkaProgram
 from .loaders.cle_loader    import CleLoader
 from .loaders.loader        import Loader, RawBinaryLoader, LoadableSegment

--- a/tritondse/loaders/coredump.py
+++ b/tritondse/loaders/coredump.py
@@ -1,0 +1,288 @@
+# built-in imports
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Generator, Tuple
+
+# third-party imports
+import lief
+from lief.ELF import CorePrStatus
+
+# local imports
+from tritondse.types import PathLike, Addr, Architecture, Platform, ArchMode, Perm, Endian, Format
+from tritondse.loaders.loader import Loader, LoadableSegment
+import tritondse.logging
+
+logger = tritondse.logging.get("loader")
+
+def cpustate_from_CONTEXT(cps):
+    return {"rax":cps.register_values[CorePrStatus.Registers.X86_64['RAX'].value],
+            "rbx":cps.register_values[CorePrStatus.Registers.X86_64['RBX'].value],
+            "rcx":cps.register_values[CorePrStatus.Registers.X86_64['RCX'].value],
+            "rdx":cps.register_values[CorePrStatus.Registers.X86_64['RDX'].value],
+            "rsp":cps.register_values[CorePrStatus.Registers.X86_64['RSP'].value],
+            "rbp":cps.register_values[CorePrStatus.Registers.X86_64['RBP'].value],
+            "rsi":cps.register_values[CorePrStatus.Registers.X86_64['RSI'].value],
+            "rdi":cps.register_values[CorePrStatus.Registers.X86_64['RDI'].value],
+            "rip":cps.register_values[CorePrStatus.Registers.X86_64['RIP'].value],
+            "r8": cps.register_values[CorePrStatus.Registers.X86_64[ 'R8'].value],
+            "r9": cps.register_values[CorePrStatus.Registers.X86_64[ 'R9'].value],
+            "r10":cps.register_values[CorePrStatus.Registers.X86_64['R10'].value],
+            "r11":cps.register_values[CorePrStatus.Registers.X86_64['R11'].value],
+            "r12":cps.register_values[CorePrStatus.Registers.X86_64['R12'].value],
+            "r13":cps.register_values[CorePrStatus.Registers.X86_64['R13'].value],
+            "r14":cps.register_values[CorePrStatus.Registers.X86_64['R14'].value],
+            "r15":cps.register_values[CorePrStatus.Registers.X86_64['R15'].value],
+            "cs": cps.register_values[CorePrStatus.Registers.X86_64[ 'CS'].value],
+            "fs": cps.register_values[CorePrStatus.Registers.X86_64[ 'FS_BASE'].value],
+            "gs": cps.register_values[CorePrStatus.Registers.X86_64[ 'GS_BASE'].value],
+            "ss": cps.register_values[CorePrStatus.Registers.X86_64[ 'SS'].value]
+            }
+
+class CoredumpLoader(Loader):
+    """
+    A specific loader for `ELF 64-bit LSB core file`, produced for example with a `generate-core-file output.dump` command.
+    Can be useful to start exploration from a breakpoint in a binary.
+    Don't forget to dump EVERYTHING, by default this command does not dump .rodata for example.
+    This can be done with an `echo 0xF > /proc/$(pidof targetprocess)/coredump_filter`
+    """
+
+    def __init__(self, path: PathLike):
+        """
+        :param path: Program path
+        :type path: :py:obj:`tritondse.types.PathLike`
+        :raise FileNotFoundError: if the file is not properly recognized by lief
+                                  or in the wrong architecture
+        """
+        super(CoredumpLoader, self).__init__(path)
+
+        self._arch_mapper = {
+            lief.Header.ARCHITECTURES.ARM:   Architecture.ARM32,
+            lief.Header.ARCHITECTURES.ARM64: Architecture.AARCH64,
+            lief.Header.ARCHITECTURES.X86:   Architecture.X86,
+            lief.Header.ARCHITECTURES.X86_64:   Architecture.X86_64
+        }
+
+        self._plfm_mapper = {
+            lief.Binary.FORMATS.ELF: Platform.LINUX,
+            lief.Binary.FORMATS.PE: Platform.WINDOWS,
+            lief.Binary.FORMATS.MACHO: Platform.MACOS
+        }
+
+        self._format_mapper = {
+            lief.Binary.FORMATS.ELF: Format.ELF,
+            lief.Binary.FORMATS.PE: Format.PE,
+            lief.Binary.FORMATS.MACHO: Format.MACHO
+        }
+
+        self.path: Path = Path(path)  #: Binary file path
+        if not self.path.is_file():
+            raise FileNotFoundError(f"file {path} not found (or not a file)")
+
+        self._binary = lief.parse(str(self.path))
+        if self._binary is None:  # lief has not been able to parse it
+            raise FileNotFoundError(f"file {path} not recognised by lief")
+
+        if self._binary.header.file_type != lief.ELF.Header.FILE_TYPE.CORE:
+            raise RuntimeError(f"file {path} is not a CORE FILE")
+
+        self._arch = self._load_arch()
+        if self._arch is None:
+            raise FileNotFoundError(f"binary {path} architecture unsupported {self._binary.abstract.header.architecture}")
+
+        try:
+            self._plfm = self._plfm_mapper[self._binary.format]
+            # TODO: better refine for Android, iOS etc.
+        except KeyError:
+            self._plfm = None
+
+        self._funs = {f.name: f for f in self._binary.concrete.functions}
+
+        if self._binary.has_notes:
+            cpustate = [n for n in self._binary.notes if n.type==lief.ELF.Note.TYPE.CORE_PRSTATUS]
+            if len(cpustate)==1:
+                self._cpustate = cpustate_from_CONTEXT(cpustate[0])
+            else:
+                raise RuntimeError(f"Not CPU context in this coredump !")
+
+    @property
+    def name(self) -> str:
+        """ Name of the loader"""
+        return f"Program({self.path})"
+
+    @property
+    def endianness(self) -> Endian:
+        return {lief.Header.ENDIANNESS.LITTLE: Endian.LITTLE,
+                lief.Header.ENDIANNESS.BIG: Endian.BIG}[self._binary.abstract.header.endianness]
+
+    @property
+    def entry_point(self) -> Addr:
+        """
+        Program entrypoint address as defined in the binary headers
+
+        :rtype: :py:obj:`tritondse.types.Addr`
+        """
+        return self._binary.entrypoint
+
+    @property
+    def architecture(self) -> Architecture:
+        """
+        Architecture enum representing program architecture.
+
+        :rtype: Architecture
+        """
+        return self._arch
+
+    @property
+    def platform(self) -> Optional[Platform]:
+        """
+        Platform of the binary. It's solely based on the format
+        of the file ELF, PE etc..
+
+        :return: Platform
+        """
+        return self._plfm
+
+    @property
+    def format(self) -> Format:
+        """
+        Binary format. Supported formats are: ELF, PE, MachO
+
+        :rtype: Format
+        """
+        return self._format_mapper[self._binary.format]
+
+    def _load_arch(self) -> Optional[Architecture]:
+        """
+        Load architecture as an Architecture object.
+
+        :return: Architecture or None if unsupported
+        """
+        arch = self._binary.abstract.header.architecture
+        if arch in self._arch_mapper:
+            arch = self._arch_mapper[arch]
+            if arch == Architecture.X86:
+                arch = Architecture.X86 if self._binary.abstract.header.is_32 else Architecture.X86_64
+            return arch
+        else:
+            return None
+
+    @property
+    def relocation_enum(self):
+        """
+        LIEF relocation enum associated with the current
+        architecture of the binary.
+
+        :return: LIEF relocation enum
+        :rtype: dict
+        """
+        arch_mapper = {
+            lief._lief.ELF.ARCH.AARCH64: "AARCH64",
+            lief._lief.ELF.ARCH.ARM: "ARM",
+            lief._lief.ELF.ARCH.I386: "I386",
+            lief._lief.ELF.ARCH.X86_64: "X86_64",
+        }
+
+        arch_str = arch_mapper[self._binary.concrete.header.machine_type]
+
+        rel_enum = {}
+        for attr_str in dir(lief.ELF.Relocation.TYPE):
+            if attr_str.startswith(arch_str):
+                attr_name = attr_str[len(arch_str) + 1:]
+                rel_enum[attr_name] = getattr(lief.ELF.Relocation.TYPE, attr_str)
+
+        return rel_enum
+
+    def _is_glob_dat(self, rel: lief.ELF.Relocation) -> bool:
+        """ Get whether the given relocation is of type GLOB_DAT.
+        Used locally to find mandatory relocations
+        """
+        rel_enum = self.relocation_enum
+
+        if 'GLOB_DAT' in rel_enum:
+            return rel.type == rel_enum['GLOB_DAT']
+        else:
+            return False  # Not GLOB_DAT relocation for this architecture
+
+    def memory_segments(self) -> Generator[LoadableSegment, None, None]:
+        """
+        Iterate over all segments of the program as loaded in memory.
+        sadly, in coredump, some are still not available as segment, but only from sections (for example .rodata) 
+
+        :return: Generator of tuples addrs and content
+        :raise NotImplementedError: if the binary format cannot be loaded
+        """
+
+        if self.format == Format.ELF:
+            for i, seg in enumerate(self._binary.segments):
+                if seg.type==lief.ELF.Segment.TYPE.LOAD:
+                    content = bytearray(seg.content)
+                    logger.info(f"Mapping seg{i} to {seg.virtual_address:0x}, with content size = {len(bytes(content))}")
+                    yield LoadableSegment(seg.virtual_address, perms=Perm(int(seg.flags)), content=bytes(content), name=f"seg{i}")
+        else:
+            raise NotImplementedError(f"memory segments not implemented for: {self.format.name}")
+
+    def imported_functions_relocations(self) -> Generator[Tuple[str, Addr], None, None]:
+        """
+        Iterate over all imported functions by the program. This function
+        is a generator of tuples associating the function and its relocation
+        address in the binary.
+
+        :return: Generator of tuples function name and relocation address
+        """
+        if self.format == Format.ELF:
+            try:
+                # Iterate functions imported through PLT
+                for rel in self._binary.concrete.pltgot_relocations:
+                    yield rel.symbol.name, rel.address
+
+                # Iterate functions imported via mandatory relocation (e.g: __libc_start_main)
+                for rel in self._binary.dynamic_relocations:
+                    if self._is_glob_dat(rel) and rel.has_symbol and not rel.symbol.is_variable:
+                        yield rel.symbol.name, rel.address
+            except Exception:
+                logger.error('Something wrong with the pltgot relocations')
+
+        else:
+            raise NotImplementedError(f"Imported functions relocations not implemented for: {self.format.name}")
+
+    def imported_variable_symbols_relocations(self) -> Generator[Tuple[str, Addr], None, None]:
+        """
+        Iterate over all imported variable symbols. Yield for each of them the name and
+        the relocation address in the binary.
+
+        :return: Generator of tuples with symbol name, relocation address
+        """
+        if self.format == Format.ELF:
+            rel_enum = self.relocation_enum
+            # Iterate imported symbols
+            for rel in self._binary.dynamic_relocations:
+                if rel.has_symbol:
+                # if rel_enum(rel.type) == rel_enum.COPY and rel.has_symbol:
+                    if rel.symbol.is_variable:
+                        yield rel.symbol.name, rel.address
+        else:
+            raise NotImplementedError(f"Imported symbols relocations not implemented for: {self.format.name}")
+
+    def find_function_addr(self, name: str) -> Optional[Addr]:
+        """
+        Search for the function name in functions of the binary.
+
+        :param name: Function name
+        :type name: str
+        :return: Address of function if found
+        :rtype: Addr
+        """
+        f = self._funs.get(name)
+        return f.address if f else None
+
+    @property
+    def arch_mode(self) -> ArchMode:
+        pass  # TODO: Richard
+
+    @property
+    def cpustate(self) -> Dict[str, int]:
+        """
+        Provide the initial cpu state in the format of a dictionary of
+        {"register_name" : register_value}
+        """
+        return self._cpustate


### PR DESCRIPTION
This PR allows to load en ELF 64-bits core file and starts emulation from the current CPU state. This can be useful to start exploration from a breakpoint in a binary.

Please note that by default, a coredump does not contain `.rodata` sections of the binary, as they are available from the filesystem. The `CoredumpLoader` does not manage this, so you need to dump everything, for example with  `echo 0xF > /proc/$(pidof targetprocess)/coredump_filter`  before using the `generate-core-file output.dump` command in GDB...
